### PR TITLE
Fix variable name in code example

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,7 +496,7 @@ $request = (new Request())
     ->withMethod('GET')
     ->withUri(new Uri('https://api.example.com/'))
     ->withHeader('Accept', 'application/json')
-    ->withBody($stream);
+    ->withBody($body);
         </code></pre>
 
         <aside class="notes">


### PR DESCRIPTION
`$body` was previously declared in line [493](https://github.com/weierophinney/2015-10-20-PSR-7-and-Middleware/compare/master...danizord:patch-1#diff-eacf331f0ffc35d4b482f1d15a887d3bR493).
